### PR TITLE
Split bonepile after kanban query

### DIFF
--- a/API_WEB/Models/Bonepile/BonepileResult.cs
+++ b/API_WEB/Models/Bonepile/BonepileResult.cs
@@ -82,4 +82,19 @@
         public string ERROR_DESC { get; set; }
         public double? AGING { get; set; }
     }
+
+    public class SerialNumberRequest
+    {
+        public List<string> SerialNumbers { get; set; }
+    }
+
+    public class BonepileAfterKanbanTestInfoResult
+    {
+        public string SERIAL_NUMBER { get; set; }
+        public string TEST_GROUP { get; set; }
+        public DateTime? TEST_TIME { get; set; }
+        public string TEST_CODE { get; set; }
+        public string ERROR_DESC { get; set; }
+        public double? AGING { get; set; }
+    }
 }


### PR DESCRIPTION
## Summary
- add bonepile-after-kanban-basic endpoint without heavy joins
- add bonepile-after-kanban-testinfo endpoint for test data
- split bonepile-after-kanban query into basic and test-info queries

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abd735fa2c832aa019072f92b5cb24