### PR TITLE
feat: add file type icons and hover styles

### DIFF
--- a/PESystem/wwwroot/assets/Areas/DataCloud/css/DataCloud.css
+++ b/PESystem/wwwroot/assets/Areas/DataCloud/css/DataCloud.css
@@ -29,6 +29,7 @@
     max-height: 100%;
     border: none;
     padding: 10px;
+    background-color: #ffffff;
 }
 
 .layout-icon {
@@ -46,11 +47,16 @@
     text-align: left;
     display: flex;
     align-items: center;
+    transition: background-color 0.2s ease;
+}
+
+.data-item:hover {
+    background-color: #e5f1fb;
 }
 
 .data-item i {
     font-size: 40px;
-    color: #5f6368;
+    color: inherit;
     margin-right: 10px;
     display: inline-block;
 }
@@ -72,9 +78,6 @@
     color: #F5D471;
 }
 
-.data-item[custom-type="File"] i {
-    color: #5f6368;
-}
 
 
 .context-menu {

--- a/PESystem/wwwroot/assets/Areas/DataCloud/js/DataCloud.js
+++ b/PESystem/wwwroot/assets/Areas/DataCloud/js/DataCloud.js
@@ -20,6 +20,41 @@
         buttonsStyling: false
     });
 
+    // Chọn icon phù hợp theo loại tệp giống Windows
+    function getFileIcon(name, type) {
+        if (type === "Folder") return "fas fa-folder";
+
+        const ext = name.split('.').pop().toLowerCase();
+        switch (ext) {
+            case 'xlsx':
+            case 'xls':
+                return 'fas fa-file-excel text-success';
+            case 'doc':
+            case 'docx':
+                return 'fas fa-file-word text-primary';
+            case 'ppt':
+            case 'pptx':
+                return 'fas fa-file-powerpoint text-warning';
+            case 'pdf':
+                return 'fas fa-file-pdf text-danger';
+            case 'jpg':
+            case 'jpeg':
+            case 'png':
+            case 'gif':
+            case 'bmp':
+                return 'fas fa-file-image text-info';
+            case 'zip':
+            case 'rar':
+            case '7z':
+                return 'fas fa-file-archive';
+            case 'txt':
+            case 'log':
+                return 'fas fa-file-alt';
+            default:
+                return 'fas fa-file';
+        }
+    }
+
 
     // Tải dữ liệu từ server (bình thường)
     function loadData(path) {
@@ -34,14 +69,15 @@
                 if (response && response.items && Array.isArray(response.items)) { // Sửa từ response.items thành response.Items
                     updateBreadcrumb(response.currentPath); // Sửa từ response.currentPath thành response.CurrentPath
                     $('#data-cloud-items').empty(); // Sử dụng #data-cloud-items để hiển thị file/folder
-                    response.items.forEach(item => {
-                        const icon = item.type === "Folder" ? "fas fa-folder" : "fas fa-file"; // Sửa item.type thành item.Type
+                    const items = response.items.filter(item => item.name !== 'RecycleBin');
+                    items.forEach(item => {
+                        const icon = getFileIcon(item.name, item.type);
                         const colElement = $('<div>').addClass('col');
-                    const itemElement = $('<div>')
-                        .addClass('data-item')
-                        .attr('custom-path', normalizePath(item.path)) // Sửa item.path thành item.Path
-                        .attr('custom-type', item.type) // Sửa item.type thành item.Type
-                        .html(`
+                        const itemElement = $('<div>')
+                            .addClass('data-item')
+                            .attr('custom-path', normalizePath(item.path)) // Sửa item.path thành item.Path
+                            .attr('custom-type', item.type) // Sửa item.type thành item.Type
+                            .html(`
                                 <i class="${icon}"></i>
                                 <span title="${item.name}">${item.name}</span>
                             `);
@@ -86,11 +122,12 @@
                 if (response && response.items && Array.isArray(response.items)) { // Sửa từ response.items thành response.Items
                     updateBreadcrumb('Search Results'); // Cập nhật breadcrumb khi tìm kiếm
                     $('#data-cloud-items').empty();
-                    if (response.items.length === 0) {
+                    const items = response.items.filter(item => item.name !== 'RecycleBin');
+                    if (items.length === 0) {
                         $('#data-cloud-items').html('<p class="text-muted">Không tìm thấy kết quả.</p>');
                     } else {
-                        response.items.forEach(item => {
-                            const icon = item.type === "Folder" ? "fas fa-folder" : "fas fa-file"; // Sửa item.type thành item.Type
+                        items.forEach(item => {
+                            const icon = getFileIcon(item.name, item.type);
                             const colElement = $('<div>').addClass('col');
                             const itemElement = $('<div>')
                                 .addClass('data-item')


### PR DESCRIPTION
## Summary
- show per-type icons for files and folders in DataCloud
- apply Windows-like background and hover highlight for file browser

## Testing
- ❌ `npm test` (Missing script: "test")
- ⚠️ `apt-get update` (403 Forbidden)
- ❌ `apt-get install -y dotnet-sdk-6.0` (Unable to locate package)
- ❌ `dotnet build` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ad36c90d44832a9cfe25cb97650343